### PR TITLE
Use correct graph and new tasks

### DIFF
--- a/delete.js
+++ b/delete.js
@@ -1,7 +1,25 @@
 import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { querySudo } from '@lblod/mu-auth-sudo';
-import { deleteFile, FILE_GRAPH } from './file-helpers';
+import { deleteFile } from './file-helpers';
 import { SparqlJsonParser } from 'sparqljson-parse';
+import * as env from 'env-var';
+
+const GRAPH_TEMPLATE = env
+  .get('GRAPH_TEMPLATE')
+  .example(
+    'http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker',
+  )
+  .default(
+    'http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker',
+  )
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(
+      `The GRAPH_TEMPLATE environment variable ${GRAPH_TEMPLATE} does not contain a ~ORGANIZATION_ID~.`,
+    );
+})();
 
 const SENT_STATUS =
   'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c';
@@ -26,7 +44,12 @@ const META_FILE_TYPE = 'http://data.lblod.gift/concepts/meta-file-type';
  * `message` (string) properties.
  */
 export async function deleteSubmission(uuid) {
-  const submissionInfo = await getSubmissionById(uuid);
+  const organisationId = await getOrganisationIdFromSubmission(uuid);
+  const submissionGraph = GRAPH_TEMPLATE.replace(
+    '~ORGANIZATION_ID~',
+    organisationId,
+  );
+  const submissionInfo = await getSubmissionById(uuid, submissionGraph);
 
   if (submissionInfo) {
     const {
@@ -38,19 +61,21 @@ export async function deleteSubmission(uuid) {
     } = submissionInfo;
     if (status !== SENT_STATUS) {
       // if not a auto-submission, nothing was harvested
-      if (taskURI) await deleteHarvestedFiles(submissionURI);
+      if (taskURI) await deleteHarvestedFiles(submissionURI, submissionGraph);
 
-      if (formDataURI) await deleteUploadedFiles(formDataURI);
+      if (formDataURI) await deleteUploadedFiles(formDataURI, submissionGraph);
       if (submissionDocumentURI)
-        await deleteLinkedTTLFiles(submissionDocumentURI);
+        await deleteLinkedTTLFiles(submissionDocumentURI, submissionGraph);
 
       // if not a auto-submission, no task was created
-      if (taskURI) await deleteResource(taskURI);
+      if (taskURI)
+        await deleteResource(taskURI, submissionGraph, submissionGraph);
 
-      if (formDataURI) await deleteResource(formDataURI);
-      if (submissionDocumentURI) await deleteResource(submissionDocumentURI);
+      if (formDataURI) await deleteResource(formDataURI, submissionGraph);
+      if (submissionDocumentURI)
+        await deleteResource(submissionDocumentURI, submissionGraph);
 
-      await deleteResource(submissionURI);
+      await deleteResource(submissionURI, submissionGraph);
       return { message: `successfully deleted submission <${submissionURI}>.` };
     }
     return {
@@ -73,13 +98,13 @@ export async function deleteSubmission(uuid) {
  * Private
  */
 
-async function deleteHarvestedFiles(uri) {
-  const files = await getHarvestedFiles(uri);
+async function deleteHarvestedFiles(uri, graph) {
+  const files = await getHarvestedFiles(uri, graph);
   for (const file of files) {
-    await deleteFile(file.parent);
-    await deleteFile(file.location);
-    await deleteResource(file.location);
-    await deleteResource(file.file);
+    await deleteFile(file.parent, graph);
+    await deleteFile(file.location, graph);
+    await deleteResource(file.location, graph);
+    await deleteResource(file.file, graph);
   }
 }
 
@@ -88,12 +113,12 @@ async function deleteHarvestedFiles(uri) {
  *
  * @param uri of the resource to delete the linked files for
  */
-async function deleteUploadedFiles(uri) {
-  const files = await getUploadedFiles(uri);
+async function deleteUploadedFiles(uri, graph) {
+  const files = await getUploadedFiles(uri, graph);
   for (const file of files) {
-    await deleteFile(file.location);
-    await deleteResource(file.file);
-    await deleteResource(file.location);
+    await deleteFile(file.location, graph);
+    await deleteResource(file.file, graph);
+    await deleteResource(file.location, graph);
   }
 }
 
@@ -102,16 +127,16 @@ async function deleteUploadedFiles(uri) {
  *
  * @param uri resource (submission-document) to delete the linked ttl files for
  */
-async function deleteLinkedTTLFiles(uri) {
-  const additionsFile = await getTTLResource(uri, ADDITIONS_FILE_TYPE);
-  const removalsFile = await getTTLResource(uri, REMOVALS_FILE_TYPE);
-  const metaFile = await getTTLResource(uri, META_FILE_TYPE);
-  const sourceFile = await getTTLResource(uri, FORM_DATA_FILE_TYPE);
+async function deleteLinkedTTLFiles(uri, graph) {
+  const additionsFile = await getTTLResource(uri, ADDITIONS_FILE_TYPE, graph);
+  const removalsFile = await getTTLResource(uri, REMOVALS_FILE_TYPE, graph);
+  const metaFile = await getTTLResource(uri, META_FILE_TYPE, graph);
+  const sourceFile = await getTTLResource(uri, FORM_DATA_FILE_TYPE, graph);
 
-  if (additionsFile) await deleteFile(additionsFile);
-  if (removalsFile) await deleteFile(removalsFile);
-  if (metaFile) await deleteFile(metaFile);
-  if (sourceFile) await deleteFile(sourceFile);
+  if (additionsFile) await deleteFile(additionsFile, graph);
+  if (removalsFile) await deleteFile(removalsFile, graph);
+  if (metaFile) await deleteFile(metaFile, graph);
+  if (sourceFile) await deleteFile(sourceFile, graph);
 }
 
 /**
@@ -119,16 +144,18 @@ async function deleteLinkedTTLFiles(uri) {
  *
  * @param uri of the resource.
  */
-async function getUploadedFiles(uri) {
+async function getUploadedFiles(uri, graph) {
   const response = await querySudo(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
     SELECT DISTINCT ?file ?location ?parent
     WHERE {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(uri)} dct:hasPart ?file .
         ?location nie:dataSource ?file .
         OPTIONAL {?parent nie:dataSource ?location .}
+      }
     }
   `);
 
@@ -149,16 +176,18 @@ async function getUploadedFiles(uri) {
  *
  * @param uri of the resource.
  */
-async function getHarvestedFiles(uri) {
+async function getHarvestedFiles(uri, graph) {
   const response = await querySudo(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
     SELECT DISTINCT ?file ?location ?parent
     WHERE {
-      ${sparqlEscapeUri(uri)} nie:hasPart ?file .
-      ?location nie:dataSource ?file .
-      ?parent nie:dataSource ?location .
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ${sparqlEscapeUri(uri)} nie:hasPart ?file .
+        ?location nie:dataSource ?file .
+        ?parent nie:dataSource ?location .
+      }
     }
   `);
 
@@ -181,7 +210,7 @@ async function getHarvestedFiles(uri) {
  * @param {string} submissionDocument URI of the submitted document to get the related file for
  * @param {string} fileType URI of the type of the related file
  */
-async function getTTLResource(submissionDocument, fileType) {
+async function getTTLResource(submissionDocument, fileType, graph) {
   const response = await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -189,10 +218,8 @@ async function getTTLResource(submissionDocument, fileType) {
 
     SELECT DISTINCT ?file
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
-      }
-      GRAPH ${sparqlEscapeUri(FILE_GRAPH)} {
         ?file dct:type ${sparqlEscapeUri(fileType)} .
       }
     } LIMIT 1
@@ -212,22 +239,22 @@ async function getTTLResource(submissionDocument, fileType) {
  *
  * @param {string} URI of the resource to delete the related files for
  */
-async function deleteResource(URI) {
+async function deleteResource(uri, graph) {
   return querySudo(`
     DELETE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(URI)} ?p ?o .
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ${sparqlEscapeUri(uri)} ?p ?o .
       }
     }
     WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(URI)} ?p ?o .
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ${sparqlEscapeUri(uri)} ?p ?o .
       }
     }
   `);
 }
 
-async function getSubmissionById(submissionId) {
+async function getSubmissionById(submissionId, graph) {
   const infoQuery = `
     PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -239,27 +266,30 @@ async function getSubmissionById(submissionId) {
     PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
     PREFIX taskO: <http://lblod.data.gift/id/jobs/concept/TaskOperation/>
 
-    SELECT DISTINCT ?submission ?formData ?submissionTask ?submissionDocument ?status WHERE {
-      ?submission a meb:Submission;
-         mu:uuid ${sparqlEscapeString(submissionId)};
-         adms:status ?status.
+    SELECT DISTINCT ?submission ?formData ?submissionTask ?submissionDocument ?status
+    WHERE {
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?submission a meb:Submission;
+           mu:uuid ${sparqlEscapeString(submissionId)};
+           adms:status ?status.
 
-      OPTIONAL {
-        ?submission prov:generated ?formData.
-        ?formData a melding:FormData.
-      }
+        OPTIONAL {
+          ?submission prov:generated ?formData.
+          ?formData a melding:FormData.
+        }
 
-      OPTIONAL {
-        ?submissionTask
-          a task:Task ;
-          task:operation taskO:register ;
-          dct:isPartOf ?job .
-        ?job prov:generated ?submission.
-      }
+        OPTIONAL {
+          ?submissionTask
+            a task:Task ;
+            task:operation taskO:register ;
+            dct:isPartOf ?job .
+          ?job prov:generated ?submission.
+        }
 
-      OPTIONAL {
-        ?submission dct:subject ?submissionDocument.
-        ?submissionDocument a ext:SubmissionDocument.
+        OPTIONAL {
+          ?submission dct:subject ?submissionDocument.
+          ?submissionDocument a ext:SubmissionDocument.
+        }
       }
     } LIMIT 1
   `;
@@ -277,4 +307,21 @@ async function getSubmissionById(submissionId) {
       taskURI: firstResult?.submissionTask?.value,
     };
   }
+}
+
+async function getOrganisationIdFromSubmission(submissionUuid) {
+  const response = await querySudo(`
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX pav:  <http://purl.org/pav/>
+
+    SELECT DISTINCT ?organisationId WHERE {
+      ?submission mu:uuid ${sparqlEscapeString(submissionUuid)} .
+      ?job prov:generated ?submission .
+      ?submission pav:createdBy ?bestuurseenheid .
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }
+    LIMIT 1
+  `);
+  return response?.results?.bindings[0]?.organisationId?.value;
 }

--- a/delete.js
+++ b/delete.js
@@ -233,31 +233,34 @@ async function getSubmissionById(submissionId) {
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+    PREFIX taskO: <http://lblod.data.gift/id/jobs/concept/TaskOperation/>
 
     SELECT DISTINCT ?submission ?formData ?submissionTask ?submissionDocument ?status WHERE {
-       ?submission a meb:Submission;
-          mu:uuid ${sparqlEscapeString(submissionId)};
-          adms:status ?status.
+      ?submission a meb:Submission;
+         mu:uuid ${sparqlEscapeString(submissionId)};
+         adms:status ?status.
 
-       OPTIONAL {
-         ?submission prov:generated ?formData.
-         ?formData a melding:FormData.
-       }
+      OPTIONAL {
+        ?submission prov:generated ?formData.
+        ?formData a melding:FormData.
+      }
 
-       OPTIONAL {
-         ?submissionTask a melding:AutomaticSubmissionTask.
-         ?submissionTask prov:generated ?submission.
-       }
+      OPTIONAL {
+        ?submissionTask
+          a task:Task ;
+          task:operation taskO:register ;
+          dct:isPartOf ?job .
+        ?job prov:generated ?submission.
+      }
 
-       OPTIONAL {
-         ?submission dct:subject ?submissionDocument.
-         ?submissionDocument a ext:SubmissionDocument.
-       }
+      OPTIONAL {
+        ?submission dct:subject ?submissionDocument.
+        ?submissionDocument a ext:SubmissionDocument.
+      }
     } LIMIT 1
   `;
 

--- a/delete.js
+++ b/delete.js
@@ -289,38 +289,33 @@ async function deleteTaskwithJob(taskUri, graph) {
 
     DELETE {
       GRAPH ${sparqlEscapeUri(graph)} {
-        ?hc2 ?hp2 ?ho2 .
         ?hc ?hp ?ho .
-        ?rc ?rp ?ro .
-        ?ic ?ip ?io .
+        ?dc ?dp ?do .
         ?task ?tp ?to .
         ?job ?jp ?jo .
       }
     } WHERE {
       GRAPH ${sparqlEscapeUri(graph)} {
-        ${sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
-        ?job ?jp ?jo .
-        ?task
-          dct:isPartOf ?job ;
-          ?tp ?to .
-
-        OPTIONAL {
-          ?task task:inputContainer ?ic .
-          ?ic ?ip ?io .
-        }
-        OPTIONAL {
-          ?task task:resultsContainer ?rc .
-          ?rc ?rp ?ro .
-        }
-
-        OPTIONAL {
-          ?ic task:hasHarvestingCollection ?hc .
+        {
+          ${sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+          ?job ?jp ?jo .
+          ?task
+            dct:isPartOf ?job ;
+            ?tp ?to .
+        } UNION {
+          VALUES ?p {
+            task:inputContainer
+            task:resultsContainer
+          }
+          ?task ?p ?dc .
+          ?dc ?dp ?do .
+        } UNION {
+          VALUES ?p {
+            task:hasHarvestingCollection
+            task:hasHarvestingCollection
+          }
+          ?dc ?p ?hc .
           ?hc ?hp ?ho .
-        }
-
-        OPTIONAL {
-          ?rc task:hasHarvestingCollection ?hc2 .
-          ?hc2 ?hp2 ?ho2 .
         }
       }
     }

--- a/delete.js
+++ b/delete.js
@@ -296,26 +296,31 @@ async function deleteTaskwithJob(taskUri, graph) {
       }
     } WHERE {
       GRAPH ${sparqlEscapeUri(graph)} {
-        {
-          ${sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
-          ?job ?jp ?jo .
-          ?task
-            dct:isPartOf ?job ;
-            ?tp ?to .
-        } UNION {
-          VALUES ?p {
-            task:inputContainer
-            task:resultsContainer
-          }
-          ?task ?p ?dc .
-          ?dc ?dp ?do .
-        } UNION {
-          VALUES ?p {
-            task:hasHarvestingCollection
-            task:hasHarvestingCollection
-          }
-          ?dc ?p ?hc .
+        ${sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+        ?job ?jp ?jo .
+        ?task
+          dct:isPartOf ?job ;
+          ?tp ?to .
+
+        OPTIONAL {
+          ?task task:inputContainer ?ic .
+          ?ic ?ip ?io .
+          ?ic task:hasHarvestingCollection ?hc .
           ?hc ?hp ?ho .
+        }
+        OPTIONAL {
+          ?task task:resultsContainer ?rc .
+          ?rc ?rp ?ro .
+          ?rc task:hasHarvestingCollection ?hc2 .
+          ?hc2 ?hp2 ?ho2 .
+        }
+        OPTIONAL {
+          ?task task:inputContainer ?ic .
+          ?ic ?ip ?io .
+        }
+        OPTIONAL {
+          ?task task:resultsContainer ?rc .
+          ?rc ?rp ?ro .
         }
       }
     }

--- a/file-helpers.js
+++ b/file-helpers.js
@@ -1,7 +1,6 @@
 import { sparqlEscapeUri } from 'mu';
 import { updateSudo as update } from '@lblod/mu-auth-sudo';
 import fs from 'fs/promises';
-import * as env from 'env-var';
 
 /**
  * Deletes a file in the triplestore and on disk

--- a/file-helpers.js
+++ b/file-helpers.js
@@ -3,15 +3,10 @@ import { updateSudo as update } from '@lblod/mu-auth-sudo';
 import fs from 'fs/promises';
 import * as env from 'env-var';
 
-export const FILE_GRAPH = env
-  .get('FILE_GRAPH')
-  .default('http://mu.semte.ch/graphs/public')
-  .asString();
-
 /**
  * Deletes a file in the triplestore and on disk
  */
-export async function deleteFile(uri) {
+export async function deleteFile(uri, graph) {
   const path = uri.replace('share://', '/share/');
 
   try {
@@ -31,11 +26,10 @@ export async function deleteFile(uri) {
       PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
       DELETE WHERE {
-        GRAPH ${sparqlEscapeUri(FILE_GRAPH)} {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(uri)} ?p ?o .
         }
-      }
-`);
+      }`);
   } catch (e) {
     console.log(
       `Failed to delete TTL resource <${uri}> in triplestore: \n ${e}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.1",
-        "env-var": "^7.3.1",
         "sparqljson-parse": "^2.2.0"
       },
       "devDependencies": {
@@ -56,9 +55,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
-      "integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -202,9 +201,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.4.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
-      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "node_modules/@types/readable-stream": {
       "version": "2.3.15",
@@ -2249,9 +2248,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "node_modules/tunnel-agent": {
@@ -2392,9 +2391,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
-      "integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -2501,9 +2500,9 @@
       }
     },
     "@types/node": {
-      "version": "20.4.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
-      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "@types/readable-stream": {
       "version": "2.3.15",
@@ -3930,9 +3929,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Microservice responsible for removing/cleaning-up submissions",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.1",
-    "env-var": "^7.3.1",
     "sparqljson-parse": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Some changes to the model of Jobs, Tasks and files came to be while working an the `automatic-submission-service` a few months ago, but this service was accidentally left out. This PR tries to update this service to accommodate those changes.

* The updated Jobs and Tasks model means that the correct Task has to identified by its operation.
* The Job, other Tasks for the same Job, and related DataContainers and HarvestingCollections are also removed.
* All data operations now only take place in the correct graph for that submission.