### PR TITLE
To sudo, or not to sudo

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,8 @@ app.delete('/submissions/:uuid', async function (req, res) {
     `Received request to delete submission-document with uuid '${uuid}'`,
   );
   try {
-    const { message, error } = await del.deleteSubmission(uuid);
+    const reqState = { canUseSudo: false };
+    const { message, error } = await del.deleteSubmission(uuid, reqState);
     if (error) {
       return res.status(error.status).send({ error: error.message });
     }
@@ -53,7 +54,11 @@ app.post('/delete-melding', async function (req, res) {
     if (!submissionUri)
       throw new Error('There was no submission URI in the request');
 
-    const { message, error } = await del.deleteSubmissionViaUri(submissionUri);
+    const reqState = { canUseSudo: true };
+    const { message, error } = await del.deleteSubmissionViaUri(
+      submissionUri,
+      reqState,
+    );
     if (error) {
       res.status(error.status || 500);
       const errorStore = errorToStore(error);

--- a/delete.js
+++ b/delete.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
+import { sparqlEscapeString, sparqlEscapeUri, query, update } from 'mu';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import { deleteFile } from './file-helpers';
 import { SparqlJsonParser } from 'sparqljson-parse';
@@ -99,7 +99,7 @@ export async function deleteSubmission(uuid) {
  */
 
 async function getSubmissionUuid(uri) {
-  const response = await querySudo(`
+  const response = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     SELECT DISTINCT ?uuid WHERE {
       ${sparqlEscapeUri(uri)} mu:uuid ?uuid .
@@ -171,7 +171,7 @@ async function deleteLinkedTTLFiles(uri, graph) {
  * @param uri of the resource.
  */
 async function getUploadedFiles(uri, graph) {
-  const response = await querySudo(`
+  const response = await query(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
@@ -203,7 +203,7 @@ async function getUploadedFiles(uri, graph) {
  * @param uri of the resource.
  */
 async function getHarvestedFiles(submissionUri, graph) {
-  const response = await querySudo(`
+  const response = await query(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
     PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
@@ -251,7 +251,7 @@ async function getHarvestedFiles(submissionUri, graph) {
  * @param {string} fileType URI of the type of the related file
  */
 async function getTTLResource(submissionDocument, fileType, graph) {
-  const response = await querySudo(`
+  const response = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
@@ -287,7 +287,7 @@ async function getTTLResource(submissionDocument, fileType, graph) {
  * @param {string} URI of the resource to delete the related files for
  */
 async function deleteResource(uri, graph) {
-  return updateSudo(`
+  return update(`
     DELETE {
       GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(uri)} ?p ?o .
@@ -302,7 +302,7 @@ async function deleteResource(uri, graph) {
 }
 
 async function deleteTaskwithJob(taskUri, graph) {
-  return updateSudo(`
+  return update(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 
@@ -389,7 +389,7 @@ async function getSubmissionById(submissionId, graph) {
     } LIMIT 1
   `;
 
-  const response = await querySudo(infoQuery);
+  const response = await query(infoQuery);
   const parser = new SparqlJsonParser();
   const parsedResults = parser.parseJsonResults(response);
   if (parsedResults.length > 0) {
@@ -405,7 +405,7 @@ async function getSubmissionById(submissionId, graph) {
 }
 
 async function getOrganisationIdFromSubmission(submissionUuid) {
-  const response = await querySudo(`
+  const response = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX pav:  <http://purl.org/pav/>

--- a/file-helpers.js
+++ b/file-helpers.js
@@ -1,5 +1,5 @@
-import { sparqlEscapeUri } from 'mu';
-import { updateSudo as update } from '@lblod/mu-auth-sudo';
+import { sparqlEscapeUri, update } from 'mu';
+import { updateSudo } from '@lblod/mu-auth-sudo';
 import fs from 'fs/promises';
 
 /**

--- a/file-helpers.js
+++ b/file-helpers.js
@@ -5,7 +5,7 @@ import fs from 'fs/promises';
 /**
  * Deletes a file in the triplestore and on disk
  */
-export async function deleteFile(uri, graph) {
+export async function deleteFile(uri, graph, canUseSudo) {
   const path = uri.replace('share://', '/share/');
 
   try {
@@ -16,7 +16,7 @@ export async function deleteFile(uri, graph) {
   }
 
   try {
-    await update(`
+    await (canUseSudo ? updateSudo : update)(`
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
       PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>


### PR DESCRIPTION
This service is accessible from outside the stack ([see the dispatcher's configuration here](https://github.com/lblod/app-meldingsplichtige-api/blob/de8735d18c82232ccb05ec682a64caebf7447ebe/config/dispatcher/dispatcher.ex#L80)) because it is needed by the frontend to delete a submission ([see here](https://github.com/lblod/frontend-meldingsplichtige-api/blob/cb1a03caaee6377dd7ac357402b81da1715ee747/app/controllers/forms/edit.js#L138)). This service used `updateSudo` and `querySudo` everywhere which means that there is no protection against malicious actor that try to delete submission by guessing a UUID. Also, logged in users could, by guessing/brute-forcing a UUID, delete submission from other organisation.

This PR switches all database access to regular `update` and `query` calls, so mu-authorization can perform its checks, solving the above concerns. There is also an endpoint that is meant for vendors to delete a submission. That endpoint performs its own authorisation. This means that the calls to the database are now parametrised with an argument to indicate if using sudo is allowed or not.

**How to test**

Make sure to check out https://github.com/lblod/app-meldingsplichtige-api/pull/33 and to pull and manually run a build for this service.

1. Make a melding and note the submission URI and its UUID.
2. Try removing the submission via something like

   ```curl -X DELETE -H "Content-Type: application/json" http://localhost/submissions/<UUID>```

   This should **not** work (but would have worked before this PR).
3. Use the frontend and log in to the correct organisation. Try to remove the submission from there (this performs the same call in in step 2, but with the session cookies). This should work.
4. Repeat step 1.
5. Try removing the submission via the vendor API like so

   ```
   curl -X POST -H "Content-Type: application/json" -d '
   {
     "submission": "<URI>",
     "organization": "<organisation URI>",
     "publisher": {
       "uri": "<vendor URI>",
       "key": "<key>"
     }
   }' http://stack/delete-melding
   ```

   This should always work.